### PR TITLE
Split README into individual AsciiDoc pages with navigation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,110 +1,12 @@
 = Josh Kurz Projects
 :toc:
 :toclevels: 2
-:sectnums:
 :sectanchors:
+
+include::nav.adoc[]
 
 Josh Kurz is a developer based in Atlanta, GA.
 
-toc::[]
+Welcome! Use the links above to explore publications, active projects, and a catalog of accomplishments.
 
-== Publications
-
-[%header,cols="1,2"]
-|===
-|Title | Link
-
-|Mastering AngularJS Directives
-|https://www.amazon.com/Mastering-AngularJS-Directives-Josh-Kurz/dp/178398158X/[Amazon]
-
-|HardenEKS: Validating Best Practices for Amazon EKS Clusters Programmatically
-|https://aws.amazon.com/blogs/containers/hardeneks-validating-best-practices-for-amazon-eks-clusters-programmatically/[AWS Blog]
-
-|5 Tips for AWS Certification Exams from AWS Solutions Architects
-|https://aws.amazon.com/blogs/training-and-certification/5-tips-for-aws-certification-exams-from-aws-solutions-architects/[AWS Blog]
-
-|ChatGPT vs Bard in a Game of Chess
-|https://medium.com/@jkurz25/chatgpt-vs-bard-in-a-game-of-chess-b3bbd796bf76[Medium]
-|===
-
-== I'm Currently Working On
-
-These repositories were updated in the past year:
-
-[%autowidth,cols="1,2",options="header"]
-|===
-|Repository | Description
-
-|🚀 https://github.com/joshkurz/joshkurz[joshkurz]
-|Josh Kurz works at JPMorgan Chase by day and moonlights as the mastermind behind joshkurz.net, where he uses advanced AI to answer life’s most pressing question: “What if dad jokes had a 401(k)?”
-
-|🚀 https://github.com/joshkurz/joshkurzsite[joshkurzsite]
-|Why don't websites ever get lost? Because they always follow their breadcrumbs.
-
-|🚀 https://github.com/joshkurz/ibjjf-elo[ibjjf-elo]
-|Why did the jiu-jitsu developer bring a ladder? To reach the next belt in the rankings.
-|===
-
-TIP: Explore these projects to see how humor and code can live in harmony. For a broader set of achievements see <<accomplishments>>.
-
-== Josh Kurz's Accomplishments [[accomplishments]]
-
-Below is a list of his public GitHub projects.
-
-=== Repositories I Created (sorted by stars)
-
-* 🐙 https://github.com/joshkurz/Black-Belt-AngularJS-Directives[Black-Belt-AngularJS-Directives] - A Directive set to help Master AngularJS Directives
-* 🐙 https://github.com/joshkurz/atlantacarlocksmith.com[atlantacarlocksmith.com] - Atlanta Locksmith Website Files
-* 🐙 https://github.com/joshkurz/exi[exi] - flask pymongo etc
-* 🐙 https://github.com/joshkurz/angular-google-maps[angular-google-maps] - Helps you find bugs faster than dad finds the remote.
-* 🐙 https://github.com/joshkurz/csssWP[csssWP] - CSSS Wordpress Plugin
-* 🐙 https://github.com/joshkurz/docker-ftw[docker-ftw] - Docker Demos for the Docker lover in all of us.
-* 🐙 https://github.com/joshkurz/ex_api[ex_api] - An API so friendly it waves at you when you log in.
-* 🐙 https://github.com/joshkurz/locksmithatlanta.com[locksmithatlanta.com] - Locksmith Atlanta Open Source Git Repository
-* 🐙 https://github.com/joshkurz/ajs_exi[ajs_exi] - Based on CaryLandholt / AngularFun Sandbox
-* 🐙 https://github.com/joshkurz/joshkurz[joshkurz] - Josh Kurz works at JPMorgan Chase by day and moonlights as the mastermind behind joshkurz.net, where he uses advanced AI to answer life’s most pressing question: “What if dad jokes had a 401(k)?”
-* 🐙 https://github.com/joshkurz/joshkurzsite[joshkurzsite] - Why don't websites ever get lost? Because they always follow their breadcrumbs.
-* 🐙 https://github.com/joshkurz/mobilelocksmithatlanta.com[mobilelocksmithatlanta.com] - The Mobile Atlanta Locksmith Open Source Code Repository
-* 🐙 https://github.com/joshkurz/thekennesawlocksmith.com[thekennesawlocksmith.com] - The Kennesaw Locksmith Open Source Git Repository
-* 🐙 https://github.com/joshkurz/thewoodstocklocksmith.com[thewoodstocklocksmith.com] - The Woodstock Locksmith Open Source Git Repository
-
-=== Other Repositories (alphabetical)
-
-* 🐙 https://github.com/joshkurz/angular[angular] - Why did the developer go broke? Because he used up all his cache.
-* 🐙 https://github.com/joshkurz/angular-gridster[angular-gridster] - An implementation of gridster-like widgets for AngularJS
-* 🐙 https://github.com/joshkurz/angular-phonecat-mongodb-rest[angular-phonecat-mongodb-rest] - Example of Angular app with Node server and MongoDb Restful API
-* 🐙 https://github.com/joshkurz/angular-snap.js[angular-snap.js] - AngularJS directive for snap.js
-* 🐙 https://github.com/joshkurz/angular-snap.js-bower[angular-snap.js-bower] - Bower component repo for angular-snap.js
-* 🐙 https://github.com/joshkurz/angular-ui[angular-ui] - AngularUI - The companion suite for AngularJS
-* 🐙 https://github.com/joshkurz/angular-ui.github.com[angular-ui.github.com] - Demo page
-* 🐙 https://github.com/joshkurz/angular.js[angular.js] - Just like my jokes, it's a bit outdated but still gets the job done.
-* 🐙 https://github.com/joshkurz/aws-eks-best-practices[aws-eks-best-practices] - A best practices guide for day 2 operations, including operational excellence, security, reliability, performance efficiency, and cost optimization.
-* 🐙 https://github.com/joshkurz/aws-iam-authenticator[aws-iam-authenticator] - A tool to use AWS IAM credentials to authenticate to a Kubernetes cluster
-* 🐙 https://github.com/joshkurz/aws-proton-workshop-code[aws-proton-workshop-code] - AWS Proton workshop - Sample Cloudformation and Terraform Templates
-* 🐙 https://github.com/joshkurz/aws-sts-proxy[aws-sts-proxy] - An OIDC Authenticated Proxy around AWS STS
-* 🐙 https://github.com/joshkurz/bootstrap[bootstrap] - Directives specific to twitter bootstrap
-* 🐙 https://github.com/joshkurz/chatbot-ui[chatbot-ui] - An open source ChatGPT UI.
-* 🐙 https://github.com/joshkurz/docker-stacks[docker-stacks] - Ready-to-run Docker images containing Jupyter applications
-* 🐙 https://github.com/joshkurz/ecsdemo-crystal[ecsdemo-crystal] - So clear even your dad can see the punchline coming.
-* 🐙 https://github.com/joshkurz/ecsdemo-frontend[ecsdemo-frontend] - Like my front yard, always under construction.
-* 🐙 https://github.com/joshkurz/ecsdemo-nodejs[ecsdemo-nodejs] - Runs faster than dad when he hears the ice cream truck.
-* 🐙 https://github.com/joshkurz/eks-blueprints-workloads[eks-blueprints-workloads] - Because every workload deserves a blueprint as solid as dad's weekend projects.
-* 🐙 https://github.com/joshkurz/eksctl[eksctl] - The official CLI for Amazon EKS
-* 🐙 https://github.com/joshkurz/es6-angularjs[es6-angularjs] - Bringing ES6 and AngularJS together like dad pairing socks that don't match.
-* 🐙 https://github.com/joshkurz/express-coffee[express-coffee] - A Template for NodeJs Application using Express, CoffeeScript, Jade, Stylus, Nib
-* 🐙 https://github.com/joshkurz/fullcalendar[fullcalendar] - Full-sized drag & drop event calendar (jQuery plugin)
-* 🐙 https://github.com/joshkurz/generative-ai-application-builder-on-aws[generative-ai-application-builder-on-aws] - Generative AI Application Builder on AWS facilitates the development, rapid experimentation, and deployment of generative artificial intelligence (AI) applications without requiring deep experience in AI. The solution includes integrations with Amazon Bedrock and its included LLMs, such as Amazon Titan, and pre-built connectors for 3rd-party LLMs.
-* 🐙 https://github.com/joshkurz/grpc-hello-service[grpc-hello-service] - grpc examples
-* 🐙 https://github.com/joshkurz/gulp-starter[gulp-starter] - Gets things running quicker than dad after his third cup of coffee.
-* 🐙 https://github.com/joshkurz/hardeneks[hardeneks] - Runs checks to see if an EKS cluster follows EKS Best Practices.
-* 🐙 https://github.com/joshkurz/hubot-datadog-snapshot[hubot-datadog-snapshot] - Hubot script for querying Datadog graph snapshots
-* 🐙 https://github.com/joshkurz/ibjjf-elo[ibjjf-elo] - Why did the jiu-jitsu developer bring a ladder? To reach the next belt in the rankings.
-* 🐙 https://github.com/joshkurz/kubectl[kubectl] - Issue tracker and mirror of kubectl code
-* 🐙 https://github.com/joshkurz/kubernetes[kubernetes] - Production-Grade Container Scheduling and Management
-* 🐙 https://github.com/joshkurz/kubetail[kubetail] - Bash script to tail Kubernetes logs from multiple pods at the same time
-* 🐙 https://github.com/joshkurz/material[material] - Material design for Angular
-* 🐙 https://github.com/joshkurz/node-dogapi[node-dogapi] - Datadog API Node.JS Client
-* 🐙 https://github.com/joshkurz/outline-markdown[outline-markdown] - Render plain text outlines into jade and html.
-* 🐙 https://github.com/joshkurz/proton-codebuild-provisioning-examples[proton-codebuild-provisioning-examples] - This repository contains sample IaC templates to demonstrate how to leverage Codebuild provisioning with AWS Proton.
-* 🐙 https://github.com/joshkurz/skywalking-nodejs[skywalking-nodejs] - The NodeJS agent for Apache SkyWalking
-* 🐙 https://github.com/joshkurz/ui-calendar[ui-calendar] - A complete AngularJS directive for the Arshaw FullCalendar.
+include::nav.adoc[]

--- a/accomplishments.adoc
+++ b/accomplishments.adoc
@@ -1,0 +1,69 @@
+= Josh Kurz's Accomplishments [[accomplishments]]
+:toc:
+:toclevels: 2
+:sectnums:
+:sectanchors:
+
+include::nav.adoc[]
+
+Below is a list of his public GitHub projects.
+
+== Repositories I Created (sorted by stars)
+
+* 🐙 https://github.com/joshkurz/Black-Belt-AngularJS-Directives[Black-Belt-AngularJS-Directives] - A Directive set to help Master AngularJS Directives
+* 🐙 https://github.com/joshkurz/atlantacarlocksmith.com[atlantacarlocksmith.com] - Atlanta Locksmith Website Files
+* 🐙 https://github.com/joshkurz/exi[exi] - flask pymongo etc
+* 🐙 https://github.com/joshkurz/angular-google-maps[angular-google-maps] - Helps you find bugs faster than dad finds the remote.
+* 🐙 https://github.com/joshkurz/csssWP[csssWP] - CSSS Wordpress Plugin
+* 🐙 https://github.com/joshkurz/docker-ftw[docker-ftw] - Docker Demos for the Docker lover in all of us.
+* 🐙 https://github.com/joshkurz/ex_api[ex_api] - An API so friendly it waves at you when you log in.
+* 🐙 https://github.com/joshkurz/locksmithatlanta.com[locksmithatlanta.com] - Locksmith Atlanta Open Source Git Repository
+* 🐙 https://github.com/joshkurz/ajs_exi[ajs_exi] - Based on CaryLandholt / AngularFun Sandbox
+* 🐙 https://github.com/joshkurz/joshkurz[joshkurz] - Josh Kurz works at JPMorgan Chase by day and moonlights as the mastermind behind joshkurz.net, where he uses advanced AI to answer life’s most pressing question: “What if dad jokes had a 401(k)?”
+* 🐙 https://github.com/joshkurz/joshkurzsite[joshkurzsite] - Why don't websites ever get lost? Because they always follow their breadcrumbs.
+* 🐙 https://github.com/joshkurz/mobilelocksmithatlanta.com[mobilelocksmithatlanta.com] - The Mobile Atlanta Locksmith Open Source Code Repository
+* 🐙 https://github.com/joshkurz/thekennesawlocksmith.com[thekennesawlocksmith.com] - The Kennesaw Locksmith Open Source Git Repository
+* 🐙 https://github.com/joshkurz/thewoodstocklocksmith.com[thewoodstocklocksmith.com] - The Woodstock Locksmith Open Source Git Repository
+
+== Other Repositories (alphabetical)
+
+* 🐙 https://github.com/joshkurz/angular[angular] - Why did the developer go broke? Because he used up all his cache.
+* 🐙 https://github.com/joshkurz/angular-gridster[angular-gridster] - An implementation of gridster-like widgets for AngularJS
+* 🐙 https://github.com/joshkurz/angular-phonecat-mongodb-rest[angular-phonecat-mongodb-rest] - Example of Angular app with Node server and MongoDb Restful API
+* 🐙 https://github.com/joshkurz/angular-snap.js[angular-snap.js] - AngularJS directive for snap.js
+* 🐙 https://github.com/joshkurz/angular-snap.js-bower[angular-snap.js-bower] - Bower component repo for angular-snap.js
+* 🐙 https://github.com/joshkurz/angular-ui[angular-ui] - AngularUI - The companion suite for AngularJS
+* 🐙 https://github.com/joshkurz/angular-ui.github.com[angular-ui.github.com] - Demo page
+* 🐙 https://github.com/joshkurz/angular.js[angular.js] - Just like my jokes, it's a bit outdated but still gets the job done.
+* 🐙 https://github.com/joshkurz/aws-eks-best-practices[aws-eks-best-practices] - A best practices guide for day 2 operations, including operational excellence, security, reliability, performance efficiency, and cost optimization.
+* 🐙 https://github.com/joshkurz/aws-iam-authenticator[aws-iam-authenticator] - A tool to use AWS IAM credentials to authenticate to a Kubernetes cluster
+* 🐙 https://github.com/joshkurz/aws-proton-workshop-code[aws-proton-workshop-code] - AWS Proton workshop - Sample Cloudformation and Terraform Templates
+* 🐙 https://github.com/joshkurz/aws-sts-proxy[aws-sts-proxy] - An OIDC Authenticated Proxy around AWS STS
+* 🐙 https://github.com/joshkurz/bootstrap[bootstrap] - Directives specific to twitter bootstrap
+* 🐙 https://github.com/joshkurz/chatbot-ui[chatbot-ui] - An open source ChatGPT UI.
+* 🐙 https://github.com/joshkurz/docker-stacks[docker-stacks] - Ready-to-run Docker images containing Jupyter applications
+* 🐙 https://github.com/joshkurz/ecsdemo-crystal[ecsdemo-crystal] - So clear even your dad can see the punchline coming.
+* 🐙 https://github.com/joshkurz/ecsdemo-frontend[ecsdemo-frontend] - Like my front yard, always under construction.
+* 🐙 https://github.com/joshkurz/ecsdemo-nodejs[ecsdemo-nodejs] - Runs faster than dad when he hears the ice cream truck.
+* 🐙 https://github.com/joshkurz/eks-blueprints-workloads[eks-blueprints-workloads] - Because every workload deserves a blueprint as solid as dad's weekend projects.
+* 🐙 https://github.com/joshkurz/eksctl[eksctl] - The official CLI for Amazon EKS
+* 🐙 https://github.com/joshkurz/es6-angularjs[es6-angularjs] - Bringing ES6 and AngularJS together like dad pairing socks that don't match.
+* 🐙 https://github.com/joshkurz/express-coffee[express-coffee] - A Template for NodeJs Application using Express, CoffeeScript, Jade, Stylus, Nib
+* 🐙 https://github.com/joshkurz/fullcalendar[fullcalendar] - Full-sized drag & drop event calendar (jQuery plugin)
+* 🐙 https://github.com/joshkurz/generative-ai-application-builder-on-aws[generative-ai-application-builder-on-aws] - Generative AI Application Builder on AWS facilitates the development, rapid experimentation, and deployment of generative artificial intelligence (AI) applications without requiring deep experience in AI. The solution includes integrations with Amazon Bedrock and its included LLMs, such as Amazon Titan, and pre-built connectors for 3rd-party LLMs.
+* 🐙 https://github.com/joshkurz/grpc-hello-service[grpc-hello-service] - grpc examples
+* 🐙 https://github.com/joshkurz/gulp-starter[gulp-starter] - Gets things running quicker than dad after his third cup of coffee.
+* 🐙 https://github.com/joshkurz/hardeneks[hardeneks] - Runs checks to see if an EKS cluster follows EKS Best Practices.
+* 🐙 https://github.com/joshkurz/hubot-datadog-snapshot[hubot-datadog-snapshot] - Hubot script for querying Datadog graph snapshots
+* 🐙 https://github.com/joshkurz/ibjjf-elo[ibjjf-elo] - Why did the jiu-jitsu developer bring a ladder? To reach the next belt in the rankings.
+* 🐙 https://github.com/joshkurz/kubectl[kubectl] - Issue tracker and mirror of kubectl code
+* 🐙 https://github.com/joshkurz/kubernetes[kubernetes] - Production-Grade Container Scheduling and Management
+* 🐙 https://github.com/joshkurz/kubetail[kubetail] - Bash script to tail Kubernetes logs from multiple pods at the same time
+* 🐙 https://github.com/joshkurz/material[material] - Material design for Angular
+* 🐙 https://github.com/joshkurz/node-dogapi[node-dogapi] - Datadog API Node.JS Client
+* 🐙 https://github.com/joshkurz/outline-markdown[outline-markdown] - Render plain text outlines into jade and html.
+* 🐙 https://github.com/joshkurz/proton-codebuild-provisioning-examples[proton-codebuild-provisioning-examples] - This repository contains sample IaC templates to demonstrate how to leverage Codebuild provisioning with AWS Proton.
+* 🐙 https://github.com/joshkurz/skywalking-nodejs[skywalking-nodejs] - The NodeJS agent for Apache SkyWalking
+* 🐙 https://github.com/joshkurz/ui-calendar[ui-calendar] - A complete AngularJS directive for the Arshaw FullCalendar.
+
+include::nav.adoc[]

--- a/nav.adoc
+++ b/nav.adoc
@@ -1,0 +1,4 @@
+* link:README.adoc[Home]
+* link:publications.adoc[Publications]
+* link:working-on.adoc[I'm Currently Working On]
+* link:accomplishments.adoc[Accomplishments]

--- a/publications.adoc
+++ b/publications.adoc
@@ -1,0 +1,26 @@
+= Publications
+:toc:
+:toclevels: 2
+:sectnums:
+:sectanchors:
+
+include::nav.adoc[]
+
+[%header,cols="1,2"]
+|===
+|Title | Link
+
+|Mastering AngularJS Directives
+|https://www.amazon.com/Mastering-AngularJS-Directives-Josh-Kurz/dp/178398158X/[Amazon]
+
+|HardenEKS: Validating Best Practices for Amazon EKS Clusters Programmatically
+|https://aws.amazon.com/blogs/containers/hardeneks-validating-best-practices-for-amazon-eks-clusters-programmatically/[AWS Blog]
+
+|5 Tips for AWS Certification Exams from AWS Solutions Architects
+|https://aws.amazon.com/blogs/training-and-certification/5-tips-for-aws-certification-exams-from-aws-solutions-architects/[AWS Blog]
+
+|ChatGPT vs Bard in a Game of Chess
+|https://medium.com/@jkurz25/chatgpt-vs-bard-in-a-game-of-chess-b3bbd796bf76[Medium]
+|===
+
+include::nav.adoc[]

--- a/working-on.adoc
+++ b/working-on.adoc
@@ -1,0 +1,27 @@
+= I'm Currently Working On
+:toc:
+:toclevels: 2
+:sectnums:
+:sectanchors:
+
+include::nav.adoc[]
+
+These repositories were updated in the past year:
+
+[%autowidth,cols="1,2",options="header"]
+|===
+|Repository | Description
+
+|🚀 https://github.com/joshkurz/joshkurz[joshkurz]
+|Josh Kurz works at JPMorgan Chase by day and moonlights as the mastermind behind joshkurz.net, where he uses advanced AI to answer life’s most pressing question: “What if dad jokes had a 401(k)?”
+
+|🚀 https://github.com/joshkurz/joshkurzsite[joshkurzsite]
+|Why don't websites ever get lost? Because they always follow their breadcrumbs.
+
+|🚀 https://github.com/joshkurz/ibjjf-elo[ibjjf-elo]
+|Why did the jiu-jitsu developer bring a ladder? To reach the next belt in the rankings.
+|===
+
+TIP: Explore these projects to see how humor and code can live in harmony. For a broader set of achievements see link:accomplishments.adoc[Josh Kurz's Accomplishments].
+
+include::nav.adoc[]


### PR DESCRIPTION
## Summary
- Separate publications, current work, and accomplishments into standalone AsciiDoc pages.
- Add shared navigation include linking the homepage and all sections.
- Simplify README to serve as a navigation hub.

## Testing
- `asciidoctor README.adoc publications.adoc working-on.adoc accomplishments.adoc`


------
https://chatgpt.com/codex/tasks/task_e_68aea5d56c9c8328a90547c4d993cae8