### PR TITLE
feat: refresh homepage and navigation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,11 +1,25 @@
-= Josh Kurz Projects
-:toc:
-:toclevels: 2
+= Welcome to Josh Kurz's Projects
 :sectanchors:
+
+*Home* › link:publications.adoc[*Publications*] › link:working-on.adoc[*I'm Currently Working On*] › link:accomplishments.adoc[*Accomplishments*]
 
 Josh Kurz builds cloud-native solutions and writes about software engineering. Use the links below to explore publications, active projects, and a catalog of accomplishments.
 
-* link:README.adoc[Home]
-* link:publications.adoc[Publications]
-* link:working-on.adoc[I'm Currently Working On]
-* link:accomplishments.adoc[Accomplishments]
+== Publications
+
+[%header,cols="1,2"]
+|===
+|Title | Link
+
+|Mastering AngularJS Directives
+|https://www.amazon.com/Mastering-AngularJS-Directives-Josh-Kurz/dp/178398158X/[Amazon]
+
+|HardenEKS: Validating Best Practices for Amazon EKS Clusters Programmatically
+|https://aws.amazon.com/blogs/containers/hardeneks-validating-best-practices-for-amazon-eks-clusters-programmatically/[AWS Blog]
+
+|5 Tips for AWS Certification Exams from AWS Solutions Architects
+|https://aws.amazon.com/blogs/training-and-certification/5-tips-for-aws-certification-exams-from-aws-solutions-architects/[AWS Blog]
+
+|ChatGPT vs Bard in a Game of Chess
+|https://medium.com/@jkurz25/chatgpt-vs-bard-in-a-game-of-chess-b3bbd796bf76[Medium]
+|===

--- a/accomplishments.adoc
+++ b/accomplishments.adoc
@@ -1,13 +1,8 @@
 = Josh Kurz's Accomplishments [[accomplishments]]
-:toc:
-:toclevels: 2
 :sectnums:
 :sectanchors:
 
-* link:README.adoc[Home]
-* link:publications.adoc[Publications]
-* link:working-on.adoc[I'm Currently Working On]
-* link:accomplishments.adoc[Accomplishments]
+link:README.adoc[*Home*] › link:publications.adoc[*Publications*] › link:working-on.adoc[*I'm Currently Working On*] › *Accomplishments*
 
 Below is a list of his public GitHub projects.
 

--- a/publications.adoc
+++ b/publications.adoc
@@ -1,13 +1,8 @@
 = Publications
-:toc:
-:toclevels: 2
 :sectnums:
 :sectanchors:
 
-* link:README.adoc[Home]
-* link:publications.adoc[Publications]
-* link:working-on.adoc[I'm Currently Working On]
-* link:accomplishments.adoc[Accomplishments]
+link:README.adoc[*Home*] › *Publications* › link:working-on.adoc[*I'm Currently Working On*] › link:accomplishments.adoc[*Accomplishments*]
 
 [%header,cols="1,2"]
 |===

--- a/working-on.adoc
+++ b/working-on.adoc
@@ -1,13 +1,8 @@
 = I'm Currently Working On
-:toc:
-:toclevels: 2
 :sectnums:
 :sectanchors:
 
-* link:README.adoc[Home]
-* link:publications.adoc[Publications]
-* link:working-on.adoc[I'm Currently Working On]
-* link:accomplishments.adoc[Accomplishments]
+link:README.adoc[*Home*] › link:publications.adoc[*Publications*] › *I'm Currently Working On* › link:accomplishments.adoc[*Accomplishments*]
 
 These repositories were updated in the past year:
 


### PR DESCRIPTION
## Summary
- make README title more inviting
- show publications table on homepage
- remove self-links from navigation across pages
- replace TOCs with breadcrumb navigation

## Testing
- `asciidoctor -o /tmp/README.html README.adoc`
- `asciidoctor -o /tmp/publications.html publications.adoc`
- `asciidoctor -o /tmp/working-on.html working-on.adoc`
- `asciidoctor -o /tmp/accomplishments.html accomplishments.adoc`


------
https://chatgpt.com/codex/tasks/task_e_68aeb3a46f748328a662d5ab05aed2f4