### PR TITLE
Remove toc and add breadcrumb navigation

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -1,13 +1,10 @@
 = Welcome to Josh Kurz's Projects
-:toc:
-:toclevels: 2
 :sectanchors:
 
-Josh Kurz builds cloud-native solutions and writes about software engineering. Use the links below to explore publications, active projects, and a catalog of accomplishments.
+[.breadcrumbs]
+🏠 *Home* › link:publications.adoc[Publications] › link:working-on.adoc[I'm Currently Working On] › link:accomplishments.adoc[Accomplishments]
 
-* link:publications.adoc[Publications]
-* link:working-on.adoc[I'm Currently Working On]
-* link:accomplishments.adoc[Accomplishments]
+Josh Kurz builds cloud-native solutions and writes about software engineering. Use the links below to explore publications, active projects, and a catalog of accomplishments.
 
 == Publications
 

--- a/accomplishments.adoc
+++ b/accomplishments.adoc
@@ -1,13 +1,9 @@
 = Josh Kurz's Accomplishments [[accomplishments]]
-:toc:
-:toclevels: 2
 :sectnums:
 :sectanchors:
 
-* link:README.adoc[Home]
-* link:publications.adoc[Publications]
-* link:working-on.adoc[I'm Currently Working On]
-* Accomplishments
+[.breadcrumbs]
+🏠 link:README.adoc[Home] › link:publications.adoc[Publications] › link:working-on.adoc[I'm Currently Working On] › *Accomplishments*
 
 Below is a list of his public GitHub projects.
 

--- a/publications.adoc
+++ b/publications.adoc
@@ -1,13 +1,9 @@
 = Publications
-:toc:
-:toclevels: 2
 :sectnums:
 :sectanchors:
 
-* link:README.adoc[Home]
-* Publications
-* link:working-on.adoc[I'm Currently Working On]
-* link:accomplishments.adoc[Accomplishments]
+[.breadcrumbs]
+🏠 link:README.adoc[Home] › *Publications* › link:working-on.adoc[I'm Currently Working On] › link:accomplishments.adoc[Accomplishments]
 
 [%header,cols="1,2"]
 |===

--- a/working-on.adoc
+++ b/working-on.adoc
@@ -1,13 +1,9 @@
 = I'm Currently Working On
-:toc:
-:toclevels: 2
 :sectnums:
 :sectanchors:
 
-* link:README.adoc[Home]
-* link:publications.adoc[Publications]
-* I'm Currently Working On
-* link:accomplishments.adoc[Accomplishments]
+[.breadcrumbs]
+🏠 link:README.adoc[Home] › link:publications.adoc[Publications] › *I'm Currently Working On* › link:accomplishments.adoc[Accomplishments]
 
 These repositories were updated in the past year:
 


### PR DESCRIPTION
## Summary
- drop table of contents directives from all pages
- replace top nav lists with emoji-styled breadcrumb navigation

## Testing
- `asciidoctor README.adoc publications.adoc working-on.adoc accomplishments.adoc`


------
https://chatgpt.com/codex/tasks/task_e_68aeb90cb4608328bf6b9d17ba5c9a16