### PR TITLE
feat: highlight fast-adoc-blog as current project

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -6,6 +6,10 @@
 
 Josh Kurz builds cloud-native solutions and writes about software engineering. Use the links below to explore publications, active projects, and a catalog of accomplishments.
 
+== Current Project
+
+*fast-adoc-blog* is a lightning-fast blog engine that turns AsciiDoc into web pages at warp speed. Dive into the live site at https://fast-adoc-blog.vercel.app/[fast-adoc-blog.vercel.app] or explore the code on https://github.com/joshkurz/fast-adoc-blog[GitHub].
+
 == Publications
 
 [%header,cols="1,2"]

--- a/working-on.adoc
+++ b/working-on.adoc
@@ -5,11 +5,14 @@
 [.breadcrumbs]
 🏠 link:README.adoc[Home] › link:publications.adoc[Publications] › *I'm Currently Working On* › link:accomplishments.adoc[Accomplishments]
 
-These repositories were updated in the past year:
+This section highlights my current project and repositories updated in the past year:
 
 [%autowidth,cols="1,2",options="header"]
 |===
 |Repository | Description
+
+|🌟 https://github.com/joshkurz/fast-adoc-blog[fast-adoc-blog]
+|*Current Focus:* A lightning-fast AsciiDoc blog engine deployed on Vercel. Read it at https://fast-adoc-blog.vercel.app/[fast-adoc-blog.vercel.app].
 
 |🚀 https://github.com/joshkurz/joshkurz[joshkurz]
 |Josh Kurz works at JPMorgan Chase by day and moonlights as the mastermind behind joshkurz.net, where he uses advanced AI to answer life’s most pressing question: “What if dad jokes had a 401(k)?”


### PR DESCRIPTION
## Summary
- showcase fast-adoc-blog as the active project on the home page with links to Vercel and GitHub
- feature fast-adoc-blog at the top of the "I'm Currently Working On" page with marketing blurb

## Testing
- `asciidoctor README.adoc working-on.adoc`

------
https://chatgpt.com/codex/tasks/task_e_68b27ab67cd88328acc1dba7cdc0a78e